### PR TITLE
Fix build script to specify input file for tsup

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "src/index.ts",
   "type": "module",
   "scripts": {
-    "build": "tsup --format esm --dts",
+    "build": "tsup src/index.ts --format esm --dts",
     "start": "tsc && node --loader ts-node/esm src/index.ts",
     "start:service:all": "pm2 start pnpm --name=\"all\" --restart-delay=3000 --max-restarts=10 -- run start:all",
     "stop:service:all": "pm2 stop all"


### PR DESCRIPTION
## Problem
The `build` script in `package.json` fails with the following error during `pnpm build`:
```
No input files, try 'tsup <your-file>' instead
```
This occurs because `tsup` requires an input file to bundle, but none is specified in the script.

## Solution
I updated the `build` script in `package.json` to specify the input file (`src/index.ts`) explicitly:
```json
{
  "scripts": {
    "build": "tsup src/index.ts --format esm --dts"
  }
}
```
This ensures the build script works as intended by providing `tsup` with the required input file.

## Testing
- Ran `pnpm build` locally, and the build completed successfully without errors.
- Verified that the generated output files are correct.

## Notes for Reviewers
No breaking changes were introduced. This fix only modifies the build script for local and CI builds.
