### PR TITLE
Update .env.example and README.md to Reflect New X Platform Credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,11 +20,11 @@ ELEVENLABS_VOICE_USE_SPEAKER_BOOST=false
 ELEVENLABS_OPTIMIZE_STREAMING_LATENCY=4
 ELEVENLABS_OUTPUT_FORMAT=pcm_16000
 
-TWITTER_DRY_RUN=false
-TWITTER_USERNAME= # Account username
-TWITTER_PASSWORD= # Account password
-TWITTER_EMAIL= # Account email
-TWITTER_COOKIES= # Account cookies
+X_DRY_RUN=false
+X_USERNAME= # Account username
+X_PASSWORD= # Account password
+X_EMAIL= # Account email
+X_COOKIES= # Account cookies
 
 X_SERVER_URL=
 XAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To load custom characters instead:
 
 ```diff
 - clients: [],
-+ clients: ["twitter", "discord"],
++ clients: ["x", "discord"],
 ```
 
 ## Duplicate the .env.example template

--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ cp .env.example .env
 -OPENROUTER_API_KEY=
 +OPENROUTER_API_KEY="sk-xx-xx-xxx"
 ...
--TWITTER_USERNAME= # Account username
--TWITTER_PASSWORD= # Account password
--TWITTER_EMAIL= # Account email
-+TWITTER_USERNAME="username"
-+TWITTER_PASSWORD="password"
-+TWITTER_EMAIL="your@email.com"
+-X_USERNAME= # Account username
+-X_PASSWORD= # Account password
+-X_EMAIL= # Account email
++X_USERNAME="username"
++X_PASSWORD="password"
++X_EMAIL="your@email.com"
 ```
 
 ## Install dependencies and start your agent


### PR DESCRIPTION
Renamed TWITTER_* variables to X_* in .env.example for updated platform. 
Updated README.md with new X_* variables and example values.

## Motivation

- Twitter has rebranded to X, requiring updates to align with the new naming conventions. Using TWITTER_* variables could cause confusion or inconsistency with the platform’s current identity.