### PR TITLE
fix README example for adding clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ To load custom characters instead:
 
 ```diff
 - clients: [],
-+ clients: [Clients.TWITTER, Clients.DISCORD],
+- clients: [Clients.TWITTER, Clients.DISCORD],
++ clients: ["twitter", "discord"],
 ```
 
 ## Duplicate the .env.example template


### PR DESCRIPTION
This PR fixes a mistake in the README file where the example for adding clients used `Clients.TWITTER`, which does not work. 
The correct usage is an array of strings, e.g., `["twitter", "discord"]`.

Changes made:
- Updated the README to show the correct example for adding clients.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated README with detailed configuration instructions for clients and environment variables
	- Added concrete examples for setting up Discord, Twitter, and OpenRouter credentials
	- Provided clear guidance on configuring client connections and API keys

<!-- end of auto-generated comment: release notes by coderabbit.ai -->