### PR TITLE
import ModelProviderName in DefaultCharacter

### DIFF
--- a/src/character.ts
+++ b/src/character.ts
@@ -1,4 +1,4 @@
-import { Character, Clients, defaultCharacter } from "@elizaos/core";
+import { Character, Clients, defaultCharacter, ModelProviderName } from "@elizaos/core";
 
 export const character: Character = {
     ...defaultCharacter,


### PR DESCRIPTION
src/character.ts is missing the ModelProviderName import, so when uncommenting, it throws an error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated import statement to include `ModelProviderName` from core module
	- No functional changes to the character implementation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->