### PR TITLE
Fix: Add --load to docker buildx build for Compose compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ docker compose up
 Make sure docker is running.
 
 ```bash
-docker buildx build --platform linux/amd64 -t eliza-starter:v1 .
+docker buildx build --platform linux/amd64 -t eliza-starter:v1 --load .
 ```
 
 #### Edit the docker-compose-image.yaml file with your environment variables


### PR DESCRIPTION
Without the --load flag, the Docker build only stores the image in cache, making it unusable for docker compose up. This fix ensures compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated Docker build command in README to include `--load` option for local image loading

<!-- end of auto-generated comment: release notes by coderabbit.ai -->