### PR TITLE
Fix/docker compose-image amd64 platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ docker compose up
 Make sure docker is running.
 
 ```bash
+# The --load flag ensures the built image is available locally
 docker buildx build --platform linux/amd64 -t eliza-starter:v1 --load .
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ docker compose up
 Make sure docker is running.
 
 ```bash
-docker buildx build --platform linux/amd64 -t eliza-starter:v1 .
+docker buildx build --platform linux/amd64 -t eliza-starter:v1 --load .
 ```
 
 #### Edit the docker-compose-image.yaml file with your environment variables

--- a/docker-compose-image.yaml
+++ b/docker-compose-image.yaml
@@ -1,5 +1,6 @@
 services:
     eliza:
+        platform: linux/amd64
         command: ["pnpm", "start", "--character=./characters/eliza.character.json"]
         image: eliza-starter:v1
         stdin_open: true


### PR DESCRIPTION
This change ensures compatibility for the Mac M-Series or aarch64 (linux/amd64) instructions in docker-compose-image.yaml, avoiding potential architecture mismatches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated README.md Docker build command to include `--load` option.
	- Added platform specification for `eliza` service in docker-compose file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->