### PR TITLE
Update License 2025

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 ai16z
+Copyright (c) 2025 ai16z
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Update year License from 2024 to 2025

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated copyright year in the MIT License from 2024 to 2025.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->