### PR TITLE
Add pm2 in dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "devDependencies": {
     "ts-node": "10.9.2",
     "tsup": "8.3.5",
-    "typescript": "5.6.3"
+    "typescript": "5.6.3",
+    "pm2": "5.4.3" 
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
         specifier: 17.7.2
         version: 17.7.2
     devDependencies:
+      pm2:
+        specifier: 5.4.3
+        version: 5.4.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       ts-node:
         specifier: 10.9.2
         version: 10.9.2(@types/node@22.10.6)(typescript@5.6.3)


### PR DESCRIPTION
## Description

pm2 was missing in dev-dependency, hence the `start:service:all` and `stop:service:all` scripts did not work. 