### PR TITLE
Fix chat api call sent to wrong port

### DIFF
--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -11,17 +11,15 @@ rl.on("SIGINT", () => {
   process.exit(0);
 });
 
-async function handleUserInput(input, agentId) {
+async function handleUserInput(input, agentId, chatEndpointConfig) {
   if (input.toLowerCase() === "exit") {
     rl.close();
     process.exit(0);
   }
 
   try {
-    const serverPort = parseInt(settings.SERVER_PORT || "3000");
-
     const response = await fetch(
-      `http://localhost:${serverPort}/${agentId}/message`,
+      `http://localhost:${chatEndpointConfig.serverPort}/${agentId}/message`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -40,11 +38,11 @@ async function handleUserInput(input, agentId) {
   }
 }
 
-export function startChat(characters) {
+export function startChat(characters, chatEndpointConfig) {
   function chat() {
     const agentId = characters[0].name ?? "Agent";
     rl.question("You: ", async (input) => {
-      await handleUserInput(input, agentId);
+      await handleUserInput(input, agentId, chatEndpointConfig);
       if (input.toLowerCase() !== "exit") {
         chat(); // Loop back to ask another question
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,8 +153,7 @@ const startAgents = async () => {
   }
 
   while (!(await checkPortAvailable(chatEndpointConfig.serverPort))) {
-    elizaLogger.warn(`Port ${chatEndpointConfig.serverPort} is in use, trying ${chatEndpointConfig.serverPort + 1}`);
-    chatEndpointConfig.serverPort++;
+    elizaLogger.warn(`Port ${chatEndpointConfig.serverPort} is in use, trying ${++chatEndpointConfig.serverPort}`);
     chatEndpointConfig.changed = true;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,7 +128,12 @@ const checkPortAvailable = (port: number): Promise<boolean> => {
 
 const startAgents = async () => {
   const directClient = new DirectClient();
-  let serverPort = parseInt(settings.SERVER_PORT || "3000");
+
+  let chatEndpointConfig = {
+    serverPort: parseInt(settings.SERVER_PORT || "3000"),
+    changed: false
+  };
+
   const args = parseArguments();
 
   let charactersArg = args.characters || args.character;
@@ -147,9 +152,10 @@ const startAgents = async () => {
     elizaLogger.error("Error starting agents:", error);
   }
 
-  while (!(await checkPortAvailable(serverPort))) {
-    elizaLogger.warn(`Port ${serverPort} is in use, trying ${serverPort + 1}`);
-    serverPort++;
+  while (!(await checkPortAvailable(chatEndpointConfig.serverPort))) {
+    elizaLogger.warn(`Port ${chatEndpointConfig.serverPort} is in use, trying ${chatEndpointConfig.serverPort + 1}`);
+    chatEndpointConfig.serverPort++;
+    chatEndpointConfig.changed = true;
   }
 
   // upload some agent functionality into directClient
@@ -158,16 +164,16 @@ const startAgents = async () => {
     return startAgent(character, directClient);
   };
 
-  directClient.start(serverPort);
+  directClient.start(chatEndpointConfig.serverPort);
 
-  if (serverPort !== parseInt(settings.SERVER_PORT || "3000")) {
-    elizaLogger.log(`Server started on alternate port ${serverPort}`);
+  if (chatEndpointConfig.changed) {
+    elizaLogger.log(`Server started on alternate port ${chatEndpointConfig.serverPort}`);
   }
 
   const isDaemonProcess = process.env.DAEMON_PROCESS === "true";
   if(!isDaemonProcess) {
     elizaLogger.log("Chat started. Type 'exit' to quit.");
-    const chat = startChat(characters);
+    const chat = startChat(characters, chatEndpointConfig);
     chat();
   }
 };


### PR DESCRIPTION
fixes #148 

Noticed the starter tries different ports in sequence starting at the configured port or 3000, before selecting one that is free.
the bug here is that chosen port is never given to the function in the chat module that makes the api call to the model. So the  chat function ends up using the old port and this causes an error.

this PR fixes that.